### PR TITLE
Fix background canvas initialization

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,5 +1,5 @@
-canvas = document.getElementById('backgroundCanvas');
-ctx = canvas.getContext('2d');
+const canvas = document.getElementById('backgroundCanvas');
+const ctx = canvas.getContext('2d');
  
 
 class Circles {
@@ -43,7 +43,7 @@ function resizeCanvas() {
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
     if (!circles) {
-        circles = new Circles(max_radius=20, num_circles=200, window=canvas.width * 2, height=canvas.height * 2)
+        circles = new Circles(20, 200, canvas.width * 2, canvas.height * 2);
     }
     circles.draw(ctx)
 }


### PR DESCRIPTION
## Summary
- Fix invalid use of Python-style named arguments when creating Circles, preventing accidental reassignment of `window`
- Use `const` declarations for canvas context to avoid implicit globals

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae419495b08322b6fe4e3fa7012f33