### PR TITLE
Add Roosevelt-inspired startup article

### DIFF
--- a/blogs/roosevelt_startups_arena.md
+++ b/blogs/roosevelt_startups_arena.md
@@ -1,0 +1,13 @@
+# Roosevelt, Startups, and the Courage to Build
+
+**Date: May 27, 2026**
+
+Theodore Roosevelt’s famous “Man in the Arena” passage from his 1910 Sorbonne speech, *Citizenship in a Republic*, remains one of the clearest descriptions of what meaningful work actually looks like. It is not polished from the outside. It is lived from the inside. The people who matter most are not the ones safely evaluating from the stands, but the ones stepping into uncertainty, taking accountability, and absorbing the consequences of their decisions.
+
+That perspective maps almost perfectly to startup life. Startups are not elegant in real time. Products launch with rough edges. Roadmaps change. Experiments fail. Teams make calls with incomplete information and then have to own the outcomes. From the outside, it can look chaotic; from the inside, it is disciplined courage repeated daily.
+
+Roosevelt’s point is not that criticism is useless, but that criticism without responsibility is cheap. In startups, the harder path is to build anyway: to ship when conditions are imperfect, to revise when reality proves you wrong, and to keep moving when confidence dips. The people doing this work will make mistakes, sometimes very visible ones, but those mistakes are often the price of learning fast enough to build something that matters.
+
+This is why the “arena” metaphor still resonates in engineering and product leadership. It affirms that execution under uncertainty is the real test. It favors ownership over commentary, iteration over image management, and practical impact over intellectual distance. In that sense, Roosevelt’s words are not just motivational; they are operational guidance for anyone trying to create value in a high-accountability environment.
+
+The enduring lesson is simple: if you want to build something meaningful, you have to be willing to be seen trying, failing, adjusting, and trying again. The arena is messy, but it is also where progress is made.

--- a/scripts/loadBlogs.js
+++ b/scripts/loadBlogs.js
@@ -1,6 +1,7 @@
 async function loadBlogList() {
     const blogContainer = document.getElementById("blog-container");
     const blogs = [
+        { title: "Roosevelt, Startups, and the Courage to Build", file: "roosevelt_startups_arena.md", year: 2026 },
         { title: "Six More Tips for Better Coding With Agents (March 2026 Edition)", file: "six_more_tips_for_coding_with_agents.md", year: 2026 },
         { title: "The Inflection Point", file: "the_inflection_point.md", year: 2026 },
         { title: "My Software Engineer Friend, You Should Join a Startup", file: "my_software_engineer_friend_you_should_join_a_startup.md", year: 2026 },


### PR DESCRIPTION
### Motivation
- Add a short, narrative article that applies Theodore Roosevelt’s “Man in the Arena” theme to startup life and practical execution. 

### Description
- Create a new blog post at `blogs/roosevelt_startups_arena.md` containing a concise, non-bullet write-up connecting Roosevelt’s passage to ownership, iteration, and risk-taking in startups. 
- Register the article in the site index by inserting a 2026 entry in `scripts/loadBlogs.js` so the post appears in the blog listing. 

### Testing
- Verified the new article content with `nl -ba blogs/roosevelt_startups_arena.md | sed -n '1,120p'`, which displayed the expected content. 
- Verified the blog index update with `nl -ba scripts/loadBlogs.js | sed -n '1,40p'`, which shows the new 2026 entry for the post.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168adecea88322aa8d47b26db2c865)